### PR TITLE
update all package references to `pocketflowframework`

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -18,7 +18,7 @@ This agent:
 3. Finally answers once enough context has been gathered.
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Placeholder for an LLM call
 async function callLLM(prompt: string): Promise<string> {

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -13,7 +13,7 @@ Here are some example applications built with the Pocket Flow Framework to demon
 A flow that processes documents through multiple stages:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 class DocumentLoaderNode extends BaseNode {
     async prep(sharedState: any) {

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -17,7 +17,7 @@ nav_order: 4
 A **BatchNode** extends `BaseNode` but changes how we handle execution:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 class MapSummaries extends BaseNode {
     // The 'prep' method returns chunks to process
@@ -61,7 +61,7 @@ await flow.run({
 A **BatchFlow** runs a **Flow** multiple times with different parameters. Think of it as a loop that replays the Flow for each parameter set.
 
 ```typescript
-import { BaseNode, BatchFlow, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, BatchFlow, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Define nodes for processing a single file
 class LoadFile extends BaseNode {

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -39,7 +39,7 @@ It can also contain local file handlers, database connections, or a combination 
 ### Example
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Placeholder for an asynchronous LLM call
 async function callLLM(prompt: string): Promise<string> {
@@ -134,7 +134,7 @@ Typically, **Params** are identifiers (e.g., file name, page number). Use them t
 ### Example
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Placeholder for an asynchronous LLM call
 async function callLLM(prompt: string): Promise<string> {

--- a/docs/core_abstraction.md
+++ b/docs/core_abstraction.md
@@ -32,7 +32,7 @@ A **BatchFlow** extends the [Flow](cci:2://file:///Users/helenazhang/Pocket-Flow
 Here’s an example of creating a simple flow with two nodes:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 class NodeA extends BaseNode {
   async prep(sharedState: any): Promise<void> {}

--- a/docs/decomp.md
+++ b/docs/decomp.md
@@ -14,7 +14,7 @@ Many real-world tasks are too complex for a single LLM call. The solution is to 
 This example demonstrates how to break down the task of writing an article into smaller, manageable steps using TypeScript and the `pocket.ts` framework.
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Placeholder for an asynchronous LLM call
 async function callLLM(prompt: string): Promise<string> {

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -33,7 +33,7 @@ A **Flow** begins with a **start** node (or another Flow). You create it using `
 Here's a minimal flow of two nodes in a chain:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Define NodeA
 class NodeA extends BaseNode {
@@ -104,7 +104,7 @@ Here's a simple expense approval flow that demonstrates branching and looping. T
 We can wire them like this:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Define ReviewExpenseNode
 class ReviewExpenseNode extends BaseNode {
@@ -265,7 +265,7 @@ In addition to the basic `Flow`, your framework supports specialized flows like 
 Continuing from the previous order processing example, suppose you want to add another layer of processing, such as logging and notification. You can create additional sub-flows or combine existing ones.
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Define LoggingNode
 class LoggingNode extends BaseNode {

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -31,7 +31,7 @@ abstract class BaseNode {
 Nodes are connected using `addSuccessor(node, action)` with "default" as the default action. Here's a complete example:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 class MyNode extends BaseNode {
   async prep(sharedState: any): Promise<any> {

--- a/docs/mapreduce.md
+++ b/docs/mapreduce.md
@@ -12,7 +12,7 @@ Process large inputs by splitting them into chunks (using something like a [Batc
 ### Example: Document Summarization
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Placeholder LLM call that takes a prompt and returns a string
 async function callLLM(prompt: string): Promise<string> {

--- a/docs/multi_agent.md
+++ b/docs/multi_agent.md
@@ -16,7 +16,7 @@ Sometimes, you want **multiple agents** (or flows) working together, each perfor
 Here's how to implement communication using a queue-like structure in Node.js. The agent listens for messages, processes them, and loops back to await more. We will simulate an asynchronous message queue using standard JavaScript patterns (e.g., an array plus `setInterval` or an event-based approach).
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // We'll define a simple queue interface
 interface MessageQueue {
@@ -118,7 +118,7 @@ Here's a more complex setup with **two agents** (a "Hinter" and a "Guesser") pla
 **Warning**: Below is a conceptual example. In a real Node.js environment, you might orchestrate concurrency differently (e.g., using `Promise.all`, or a dedicated event system).
 
 ```typescript
-import { BaseNode, Flow } from "../src/pocket";
+import { BaseNode, Flow } from "pocketflowframework";
 
 // Placeholder LLM function (replace with real calls as needed)
 async function callLLM(prompt: string): Promise<string> {

--- a/docs/node.md
+++ b/docs/node.md
@@ -72,7 +72,7 @@ By default, it rethrows the exception. But you can return a fallback result inst
 Below is a Node that reads file content from `sharedState`, calls an LLM to summarize it, and saves the result back:
 
 ```typescript
-import { BaseNode, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, DEFAULT_ACTION } from "pocketflowframework";
 import { callLLM } from "../path/to/your/llm-wrapper";
 
 export class SummarizeFile extends BaseNode {

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -17,7 +17,7 @@ nav_order: 6
 This concept is akin to an **AsyncBatchNode** but runs `execAsync()` in **parallel** for each item. Let's define a `ParallelSummaries` node that splits an array of texts, calls an LLM for each one **in parallel**, and then combines results:
 
 ```typescript
-import { AsyncParallelBatchNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { AsyncParallelBatchNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 import { callLLM } from "../path/to/your/llm-wrapper";
 
 export class ParallelSummaries extends AsyncParallelBatchNode<string, string> {
@@ -71,7 +71,7 @@ flow.runAsync(shared).then(() => {
 A **parallel** version of a **BatchFlow**, where each iteration of a sub-flow runs **concurrently** using different parameters. For example, if you have a **LoadAndSummarizeFile** flow, you can run it in parallel for multiple files at once.
 
 ```typescript
-import { AsyncParallelBatchFlow, Flow } from "../src/pocket";
+import { AsyncParallelBatchFlow, Flow } from "pocketflowframework";
 import { LoadAndSummarizeFile } from "./somewhere";
 
 export class SummarizeMultipleFiles extends AsyncParallelBatchFlow {

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -15,7 +15,7 @@ When building LLM applications that **answer questions** from a corpus of docume
 Below is a two-Node flow in **TypeScript** that **builds an embedding index** and **answers questions** via a retrieval step.
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 /** 
  * Placeholder for your embedding + index building code.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -58,7 +58,7 @@ When prompting an LLM for **structured** output:
 Below is a **TypeScript** Node (`BaseNode`) demonstrating how to prompt an LLM for a YAML-based summary. It prompts for exactly 3 bullet points and then parses the LLM's response as YAML.
 
 ```typescript
-import { BaseNode, DEFAULT_ACTION } from "../src/pocket";
+import { BaseNode, DEFAULT_ACTION } from "pocketflowframework";
 import { callLLM } from "../path/to/your/llm-wrapper";
 
 /**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,13 +13,13 @@ This document demonstrates how to use **pocket.ts** in a typical TypeScript proj
 ## 1. Install & Import
 
 ```bash
-npm install pocket-ts
+npm install pocketflowframework
 ```
 
 In your TypeScript code:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "pocket-ts"; 
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework"; 
 // Adjust import if your local path is different or you have a monorepo structure
 ```
 
@@ -179,7 +179,7 @@ Most LLM-based tasks or external API calls require **async**. With `pocket.ts`, 
 Below is a small end-to-end flow:
 
 ```typescript
-import { BaseNode, Flow, DEFAULT_ACTION } from "pocket-ts";
+import { BaseNode, Flow, DEFAULT_ACTION } from "pocketflowframework";
 
 // Node #1: Greet user
 class GreetNode extends BaseNode {

--- a/docs/viz.md
+++ b/docs/viz.md
@@ -14,7 +14,7 @@ We don't provide built-in visualization and debugging. Here are some minimal imp
 This code recursively traverses the nested graph, assigns unique IDs to each node, and treats Flow nodes as subgraphs to generate Mermaid syntax for a hierarchical visualization.
 
 ```typescript
-import { BaseNode, Flow } from "../src/pocket";
+import { BaseNode, Flow } from "pocketflowframework";
 
 export function buildMermaid(start: BaseNode | Flow): string {
     const ids = new Map<any, string>();
@@ -78,7 +78,7 @@ export function buildMermaid(start: BaseNode | Flow): string {
 Here's a utility to help debug the execution flow of nodes by tracking the call stack:
 
 ```typescript
-import { BaseNode } from "../src/pocket";
+import { BaseNode } from "pocketflowframework";
 
 export function getNodeCallStack(): string[] {
     const stack = new Error().stack?.split("\n").slice(1) || [];


### PR DESCRIPTION
The documentation currently points to Pocket by using:
* `pocket-ts`
* `pocket`
* `../src/pocket`.

Only the latter is valid, but requiring developers to clone a git repo and then use `../src/pocket` is bad DX.
It seems that `pocketflowframework` has already been published, so I wonder why it has not been promoted in this repo.

I would appreciate understanding some of the decisions made in order to help with more PRs.